### PR TITLE
feat(tools): implement dm, who, register, broadcast handlers

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,18 +1,136 @@
 // MCP tool handlers: dm, who, register, broadcast
 
-export function handleDm(from: string, to: string, content: string): void {
-  // TODO: Write DM to bus via writeMessage
+import { writeMessage, readMessages, listActiveSessions, registerSession } from "./bus.js";
+
+export type DmResult = {
+  success: boolean;
+  to: string;
+  messageId?: number;
+  error?: string;
+};
+
+export type WhoResult = {
+  sessions: Array<{ id: string; role: string; last_seen: string }>;
+  count: number;
+};
+
+export type RegisterResult = {
+  success: boolean;
+  sessionId: string;
+  role: string;
+  error?: string;
+};
+
+export type BroadcastResult = {
+  success: boolean;
+  from: string;
+  recipientCount: number;
+  error?: string;
+};
+
+function sanitize(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, "-");
 }
 
-export function handleWho(): any[] {
-  // TODO: Return active sessions via listActiveSessions
-  return [];
+export function handleRegister(sessionId: string, role: string): RegisterResult {
+  try {
+    if (!sessionId || sessionId.trim().length === 0) {
+      return { success: false, sessionId: "", role: "", error: "sessionId is required" };
+    }
+    if (sessionId.length > 64) {
+      return { success: false, sessionId: "", role: "", error: "sessionId must be 64 chars or less" };
+    }
+    if (!role || role.trim().length === 0) {
+      return { success: false, sessionId: "", role: "", error: "role is required" };
+    }
+    if (role.length > 64) {
+      return { success: false, sessionId: "", role: "", error: "role must be 64 chars or less" };
+    }
+
+    const cleanId = sanitize(sessionId);
+    const cleanRole = sanitize(role);
+    registerSession(cleanId, cleanRole);
+    return { success: true, sessionId: cleanId, role: cleanRole };
+  } catch (err) {
+    return { success: false, sessionId: "", role: "", error: String(err) };
+  }
 }
 
-export function handleRegister(sessionId: string, role: string): void {
-  // TODO: Register session via registerSession
+export function handleDm(from: string, to: string, content: string): DmResult {
+  try {
+    if (!from || from.trim().length === 0) {
+      return { success: false, to: "", error: "from is required" };
+    }
+    if (!to || to.trim().length === 0) {
+      return { success: false, to: "", error: "to is required" };
+    }
+    if (!content || content.trim().length === 0) {
+      return { success: false, to: "", error: "content is required" };
+    }
+    if (content.length > 10_000) {
+      return { success: false, to: "", error: "content must be under 10000 chars" };
+    }
+
+    writeMessage(from, to, content);
+    return { success: true, to };
+  } catch (err) {
+    return { success: false, to: "", error: String(err) };
+  }
 }
 
-export function handleBroadcast(from: string, content: string): void {
-  // TODO: Write message to all active sessions except sender
+export function handleWho(): WhoResult {
+  try {
+    const sessions = listActiveSessions();
+    return { sessions, count: sessions.length };
+  } catch {
+    return { sessions: [], count: 0 };
+  }
+}
+
+export function handleBroadcast(from: string, content: string): BroadcastResult {
+  try {
+    if (!from || from.trim().length === 0) {
+      return { success: false, from: "", recipientCount: 0, error: "from is required" };
+    }
+    if (!content || content.trim().length === 0) {
+      return { success: false, from, recipientCount: 0, error: "content is required" };
+    }
+    if (content.length > 10_000) {
+      return { success: false, from, recipientCount: 0, error: "content must be under 10000 chars" };
+    }
+
+    const sessions = listActiveSessions();
+    const recipientCount = sessions.filter((s) => s.id !== from).length;
+
+    writeMessage(from, "all", content);
+
+    return { success: true, from, recipientCount };
+  } catch (err) {
+    return { success: false, from: "", recipientCount: 0, error: String(err) };
+  }
+}
+
+// Smoke test — only runs when executed directly: bun run src/tools.ts
+if (import.meta.main) {
+  const { initBus } = await import("./bus.js");
+
+  initBus();
+
+  const reg1 = handleRegister("planner", "orchestrator");
+  console.log("register planner:", reg1);
+
+  const reg2 = handleRegister("backend", "worker");
+  console.log("register backend:", reg2);
+
+  const dm = handleDm("planner", "backend", "scaffold the auth module");
+  console.log("dm planner→backend:", dm);
+
+  const bc = handleBroadcast("planner", "standup in 5");
+  console.log("broadcast from planner:", bc);
+
+  const who = handleWho();
+  console.log("who:", who);
+
+  const msgs = readMessages("backend");
+  console.log("backend messages:", msgs);
 }


### PR DESCRIPTION
Full implementation of src/tools.ts — the four MCP tool handlers.

- handleRegister(): validates, sanitizes, upserts session into bus
- handleDm(): validates and writes direct message to bus
- handleWho(): returns all active sessions with count
- handleBroadcast(): writes to_session='all' for current and future sessions,
  computes recipientCount from active sessions minus sender

All four handlers return typed result objects, never throw.
Smoke test passing — backend received exactly 2 messages as expected.
bun run typecheck clean.