### PR TITLE
fix(broadcast): eliminate delivered flag race condition

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -100,11 +100,13 @@ export function handleBroadcast(from: string, content: string): BroadcastResult 
     }
 
     const sessions = listActiveSessions();
-    const recipientCount = sessions.filter((s) => s.id !== from).length;
+    const recipients = sessions.filter((s) => s.id !== from);
 
-    writeMessage(from, "all", content);
+    for (const session of recipients) {
+      writeMessage(from, session.id, content);
+    }
 
-    return { success: true, from, recipientCount };
+    return { success: true, from, recipientCount: recipients.length };
   } catch (err) {
     return { success: false, from: "", recipientCount: 0, error: String(err) };
   }


### PR DESCRIPTION
Broadcast previously wrote a single `to_session='all'` row. Both sessions' poll
loops match `to_session='all'`, so whichever poll fired first marked `delivered=1`
globally — the other session never saw the message.

Fix: write one row per recipient with their specific session ID as `to_session`.
Each row is only matched by its target session's query, eliminating the race.

Smoke test confirms 2 messages for backend (DM + broadcast), no duplication.