### PR TITLE
feat: SKILL.md, install.sh, plugin.json — ship v0.1.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,91 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-echo "cc-dm installer — coming soon"
-echo "For now, clone the repo and run: bun install"
+REPO="https://github.com/Akram012388/cc-dm"
+INSTALL_DIR="$HOME/.cc-dm/plugin"
+CONFIG_FILE="$HOME/.claude.json"
+
+echo ""
+echo "cc-dm — Claude Code Direct Message"
+echo "===================================="
+echo ""
+
+# Check dependencies
+if ! command -v bun &> /dev/null; then
+  echo "ERROR: Bun is required but not installed."
+  echo "Install it from: https://bun.sh"
+  exit 1
+fi
+
+if ! command -v git &> /dev/null; then
+  echo "ERROR: git is required but not installed."
+  exit 1
+fi
+
+CLAUDE_VERSION=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
+REQUIRED_VERSION="2.1.80"
+
+version_gte() {
+  printf '%s\n%s\n' "$2" "$1" | sort -V -C
+}
+
+if ! version_gte "$CLAUDE_VERSION" "$REQUIRED_VERSION"; then
+  echo "ERROR: Claude Code v$REQUIRED_VERSION or later is required."
+  echo "Your version: $CLAUDE_VERSION"
+  echo "Update Claude Code and try again."
+  exit 1
+fi
+
+echo "✓ Bun found: $(bun --version)"
+echo "✓ Claude Code found: v$CLAUDE_VERSION"
+echo ""
+
+# Clone or update repo
+if [ -d "$INSTALL_DIR/.git" ]; then
+  echo "Updating existing installation..."
+  git -C "$INSTALL_DIR" pull origin main --quiet
+else
+  echo "Installing cc-dm to $INSTALL_DIR..."
+  mkdir -p "$(dirname "$INSTALL_DIR")"
+  git clone "$REPO" "$INSTALL_DIR" --quiet
+fi
+
+# Install dependencies
+echo "Installing dependencies..."
+bun install --cwd "$INSTALL_DIR" --quiet
+
+# Inject MCP server config into ~/.claude.json
+echo "Configuring Claude Code..."
+
+MCP_ENTRY=$(cat <<EOF
+{
+  "command": "bun",
+  "args": ["run", "$INSTALL_DIR/src/server.ts"]
+}
+EOF
+)
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo '{}' > "$CONFIG_FILE"
+fi
+
+# Use bun to safely merge the config
+bun -e "
+const fs = require('fs');
+const config = JSON.parse(fs.readFileSync('$CONFIG_FILE', 'utf8'));
+if (!config.mcpServers) config.mcpServers = {};
+config.mcpServers['cc-dm'] = $MCP_ENTRY;
+fs.writeFileSync('$CONFIG_FILE', JSON.stringify(config, null, 2));
+console.log('MCP server registered in ~/.claude.json');
+"
+
+echo ""
+echo "===================================="
+echo "cc-dm installed successfully."
+echo ""
+echo "To start a session:"
+echo "  CC_DM_SESSION_ID=myname claude --dangerously-load-development-channels server:cc-dm"
+echo ""
+echo "Docs: $REPO"
+echo "===================================="
+echo ""

--- a/plugin.json
+++ b/plugin.json
@@ -1,12 +1,20 @@
 {
   "name": "cc-dm",
   "version": "0.1.0",
-  "description": "Peer-to-peer direct messaging between Claude Code sessions",
+  "description": "Peer-to-peer direct messaging between Claude Code sessions via the Channels protocol",
   "author": "Akram Al-Balushi",
+  "license": "MIT",
+  "repository": "https://github.com/Akram012388/cc-dm",
+  "keywords": ["claude-code", "mcp", "channels", "multi-agent", "sessions"],
   "mcpServers": {
     "cc-dm": {
       "command": "bun",
       "args": ["run", "src/server.ts"]
     }
-  }
+  },
+  "skills": [
+    "skills/cc-dm"
+  ],
+  "minClaudeCodeVersion": "2.1.80",
+  "channelCapable": true
 }

--- a/skills/cc-dm/SKILL.md
+++ b/skills/cc-dm/SKILL.md
@@ -1,8 +1,73 @@
 ---
 name: cc-dm
-description: Use cc-dm to send direct messages between active Claude Code sessions on this machine
+description: Use cc-dm to send and receive direct messages between active Claude Code sessions on this machine
+triggers:
+  - "dm"
+  - "direct message"
+  - "message the"
+  - "tell the"
+  - "notify"
+  - "broadcast"
+  - "who is active"
+  - "who is online"
+  - "cc-dm"
 ---
 
-# cc-dm skill
+# cc-dm — Claude Code Direct Message
 
-TODO: Full skill instructions to be written after core implementation is complete.
+cc-dm is a peer-to-peer message bus for Claude Code sessions running on
+the same machine. Use it to coordinate between parallel sessions without
+copy-pasting context manually.
+
+## On startup
+
+Always register this session when cc-dm is available:
+
+  Use the register tool to register this session.
+  Use the current session name as session_id and a short role description.
+  Example: register(session_id="planner", role="orchestrator")
+
+## Sending a direct message
+
+When the user says "dm [session] [message]" or "tell [session] [message]":
+
+  Use the dm tool.
+  Example: dm(to="backend", content="auth spec is ready")
+
+The message is delivered to the target session within 500ms.
+You do not need to wait for a reply — continue your work.
+
+## Receiving a message
+
+Incoming messages arrive as a <channel> event in your context:
+
+  <channel source="cc-dm" from_session="planner" to_session="backend">
+    auth spec is ready
+  </channel>
+
+When you receive a <channel> event:
+1. Acknowledge it briefly in your response
+2. Act on the instruction if it is addressed to your session id
+3. Optionally reply using the dm tool
+
+## Broadcasting
+
+When the user says "broadcast [message]" or "tell all sessions [message]":
+
+  Use the broadcast tool.
+  Example: broadcast(content="wrapping up in 10 minutes")
+
+## Checking who is online
+
+When the user asks "who is active" or "who is online" or "list sessions":
+
+  Use the who tool.
+  It returns all sessions with active heartbeats on this machine.
+
+## Rules
+
+- Never use console.log — you are inside an MCP stdio session
+- Do not poll manually — messages arrive automatically via the channel
+- Do not register more than once per session startup
+- If a dm fails, report the error and move on — do not retry in a loop
+- Messages to offline sessions are queued and delivered when they reconnect


### PR DESCRIPTION
Final pieces for v0.1.0 release.

**SKILL.md**
Full skill implementation teaching Claude how to use cc-dm naturally.
Covers: startup registration, sending DMs, receiving <channel> events,
broadcasting, checking who is online, and behavioral rules.

**install.sh**
curl | bash installer. Checks Bun, git, and Claude Code version (>=2.1.80).
Clones or updates repo to ~/.cc-dm/plugin, runs bun install, injects MCP
server config into ~/.claude.json safely using bun.

**plugin.json**
Finalized manifest with repository, keywords, skills reference,
minClaudeCodeVersion, and channelCapable flag.

All tests passing. bun run typecheck clean. install.sh executable.

---
v0.1.0 — first working release of cc-dm.