### PR TITLE
fix: use relative path in .mcp.json for local dev

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "cc-dm": {
       "command": "bun",
-      "args": ["run", "${CLAUDE_PLUGIN_ROOT}/src/server.ts"]
+      "args": ["run", "src/server.ts"]
     }
   }
 }


### PR DESCRIPTION
CLAUDE_PLUGIN_ROOT is only set when loaded as an installed plugin. .mcp.json is for local development and needs a relative path. plugin.json keeps the variable for installed plugin context.