### PR TITLE
Add npm package metadata and install docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [1.1.0] - 2026-03-24
 
 ### Added
+- Published to npm as [`cc-dm`](https://www.npmjs.com/package/cc-dm) for OSS discoverability
+- `files`, `repository`, `homepage`, `bugs`, `keywords`, `engines`, `publishConfig` fields in package.json
+- `prepublishOnly` script runs typecheck + tests before every publish
 - Project-scoped messaging — sessions can set an optional `project` tag during registration; both broadcasts and DMs from a session with a project tag only reach sessions with the same tag
 - `project` column on sessions table with automatic schema migration for existing DBs
 - `CC_DM_SESSION_PROJECT` env var for pre-configuring project at launch

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # cc-dm
 
+[![npm version](https://img.shields.io/npm/v/cc-dm.svg)](https://www.npmjs.com/package/cc-dm)
+[![license](https://img.shields.io/npm/l/cc-dm.svg)](https://github.com/Akram012388/cc-dm/blob/main/LICENSE)
+
 Peer-to-peer direct messaging between Claude Code sessions.
 
 ## What it does
@@ -38,7 +41,19 @@ Start a new Claude Code session and enter the following commands:
 
 Restart Claude Code. The cc-dm tools and skills will be available in all sessions.
 
-## Install (alternative)
+## Install (alternative methods)
+
+**Via npm** (requires [Bun](https://bun.sh)):
+
+```bash
+npm install cc-dm
+```
+
+The npm package contains the full plugin source. After installing, follow the [Quick Start](#quick-start) above to register the plugin with Claude Code.
+
+> **Note:** cc-dm is a Claude Code channel plugin, not a standalone library. The npm package exists for discoverability and as a distribution mirror — the primary install method is the plugin marketplace above.
+
+**Via curl:**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Akram012388/cc-dm/main/install.sh | bash
@@ -153,7 +168,7 @@ bun -e "
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| [v1.1.0](https://github.com/Akram012388/cc-dm/releases/tag/v1.1.0) | 2026-03-24 | Project-scoped messaging — tag sessions to a project, broadcasts and DMs stay within project |
+| [v1.1.0](https://github.com/Akram012388/cc-dm/releases/tag/v1.1.0) | 2026-03-24 | Project-scoped messaging, [npm package](https://www.npmjs.com/package/cc-dm) published |
 | [v1.0.0](https://github.com/Akram012388/cc-dm/releases/tag/v1.0.0) | 2026-03-22 | Production release — duplicate delivery guard, same-name protection, stronger session IDs |
 | [v0.3.0](https://github.com/Akram012388/cc-dm/releases/tag/v0.3.0) | 2026-03-22 | Fix MCP server path resolution for plugin marketplace installs |
 | [v0.2.0](https://github.com/Akram012388/cc-dm/releases/tag/v0.2.0) | 2026-03-21 | 44-test suite, clean shutdown, bus hardening |

--- a/package.json
+++ b/package.json
@@ -6,11 +6,42 @@
   "license": "MIT",
   "type": "module",
   "main": "src/server.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Akram012388/cc-dm.git"
+  },
+  "homepage": "https://github.com/Akram012388/cc-dm#readme",
+  "bugs": {
+    "url": "https://github.com/Akram012388/cc-dm/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "claude",
+    "channels",
+    "plugin",
+    "mcp",
+    "direct-messaging",
+    "multi-session"
+  ],
+  "engines": {
+    "bun": ">=1.0.0"
+  },
+  "files": [
+    "src/",
+    "skills/",
+    ".claude-plugin/plugin.json",
+    "install.sh",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "bun install --no-summary && bun src/server.ts",
     "dev": "bun --watch src/server.ts",
     "typecheck": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "prepublishOnly": "bun run typecheck && bun test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1"


### PR DESCRIPTION
## Summary
- Published `cc-dm@1.1.0` to npm ([npmjs.com/package/cc-dm](https://www.npmjs.com/package/cc-dm)) for OSS discoverability
- Added npm metadata to `package.json`: `repository`, `homepage`, `bugs`, `keywords`, `engines`, `files` allowlist, `publishConfig`, `prepublishOnly` script
- Updated README with npm/license badges and npm install instructions (with clear note that marketplace is the primary install method)
- Updated CHANGELOG to document npm publishing under v1.1.0

## What is NOT changed
- Zero logic or design changes to existing codebase
- No existing `package.json` fields modified — only new fields added
- No source code touched
- No new source files created
- Version remains 1.1.0

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` — 88 pass, 0 fail
- [x] `bun pm pack --dry-run` — 13 files, 50.52KB (clean tarball)
- [x] `bun publish` — cc-dm@1.1.0 live on npm registry
- [x] Verified on npmjs.com: metadata, README, links all correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)