### PR TITLE
feat: add message meta attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to cc-dm will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- Message meta attributes — `dm` and `broadcast` tools accept optional `priority` (urgent/normal/low), `message_type` (task/question/status/review), and `thread_id` for conversation threading
+- `meta TEXT` column on messages table with JSON storage and automatic schema migration for existing DBs
+- `validateMetaKeys()` and `buildMeta()` helpers in `tools.ts` — meta keys validated against channel protocol constraints (letters, digits, underscores only)
+- Stored meta attributes included in channel notification delivery — user meta spread BEFORE hardcoded routing fields to prevent spoofing
+- 16 new tests for meta round-trip, key validation, corrupted JSON fallback, and tool integration (110 total)
+
 ## [1.2.0] - 2026-03-27
 
 ### Added

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -60,10 +60,18 @@ export function initBus(dbPath?: string): void {
         from_session  TEXT NOT NULL,
         to_session    TEXT NOT NULL,
         content       TEXT NOT NULL,
+        meta          TEXT NOT NULL DEFAULT '{}',
         delivered     INTEGER NOT NULL DEFAULT 0,
         created_at    TEXT NOT NULL
       );
     `);
+
+    // Migration: add meta column for existing DBs
+    try {
+      db.run(`ALTER TABLE messages ADD COLUMN meta TEXT NOT NULL DEFAULT '{}'`);
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("duplicate column"))) throw err;
+    }
 
     db.run(`
       CREATE INDEX IF NOT EXISTS idx_messages_to_delivered
@@ -142,13 +150,13 @@ export function expireStaleSessions(): void {
 
 // Note: fromName is a display name stored in the from_session column for
 // historical reasons. It is NOT a session ID — do not JOIN against sessions.id.
-export function writeMessage(fromName: string, toSessionId: string, content: string): boolean {
+export function writeMessage(fromName: string, toSessionId: string, content: string, meta: Record<string, string> = {}): boolean {
   try {
     const now = new Date().toISOString();
     db.run(
-      `INSERT INTO messages (from_session, to_session, content, delivered, created_at)
-       VALUES (?, ?, ?, 0, ?)`,
-      [fromName, toSessionId, content, now]
+      `INSERT INTO messages (from_session, to_session, content, meta, delivered, created_at)
+       VALUES (?, ?, ?, ?, 0, ?)`,
+      [fromName, toSessionId, content, JSON.stringify(meta), now]
     );
     return true;
   } catch (err) {
@@ -157,13 +165,17 @@ export function writeMessage(fromName: string, toSessionId: string, content: str
   }
 }
 
-export function readPendingMessages(sessionId: string): Array<{ id: number; from_session: string; content: string; created_at: string }> {
+export function readPendingMessages(sessionId: string): Array<{ id: number; from_session: string; content: string; meta: Record<string, string>; created_at: string }> {
   try {
-    return db.query<{ id: number; from_session: string; content: string; created_at: string }, [string]>(
-      `SELECT id, from_session, content, created_at FROM messages
+    const rows = db.query<{ id: number; from_session: string; content: string; meta: string; created_at: string }, [string]>(
+      `SELECT id, from_session, content, meta, created_at FROM messages
        WHERE to_session = ? AND delivered = 0
        ORDER BY id ASC`
     ).all(sessionId);
+    return rows.map((row) => ({
+      ...row,
+      meta: (() => { try { return JSON.parse(row.meta); } catch { return {}; } })(),
+    }));
   } catch (err) {
     console.error("[cc-dm/bus] readPendingMessages failed:", err);
     return [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import {
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { initBus, readPendingMessages, deleteDeliveredMessage, deregisterSession, registerSession } from "./bus.js";
-import { handleDm, handleWho, handleRegister, handleBroadcast, withIdentity } from "./tools.js";
+import { handleDm, handleWho, handleRegister, handleBroadcast, withIdentity, buildMeta } from "./tools.js";
 import { startHeartbeat, stopHeartbeat } from "./heartbeat.js";
 import { sanitize } from "./sanitize.js";
 
@@ -106,6 +106,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: "string",
             description: "Message content to send",
           },
+          priority: {
+            type: "string",
+            enum: ["urgent", "normal", "low"],
+            description: "Message priority (default: normal)",
+          },
+          message_type: {
+            type: "string",
+            enum: ["task", "question", "status", "review"],
+            description: "Message type for categorization",
+          },
+          thread_id: {
+            type: "string",
+            maxLength: 64,
+            description: "Thread ID for conversation threading",
+          },
         },
         required: ["to", "content"],
       },
@@ -128,6 +143,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           content: {
             type: "string",
             description: "Message to send to all active sessions",
+          },
+          priority: {
+            type: "string",
+            enum: ["urgent", "normal", "low"],
+            description: "Message priority (default: normal)",
+          },
+          message_type: {
+            type: "string",
+            enum: ["task", "question", "status", "review"],
+            description: "Message type for categorization",
+          },
+          thread_id: {
+            type: "string",
+            maxLength: 64,
+            description: "Thread ID for conversation threading",
           },
         },
         required: ["content"],
@@ -160,11 +190,22 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       return { content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }] };
     }
     case "dm": {
+      const { meta, error: metaError } = buildMeta(
+        req.params.arguments?.priority as string | undefined,
+        req.params.arguments?.message_type as string | undefined,
+        req.params.arguments?.thread_id as string | undefined,
+      );
+      if (metaError) {
+        const errResult = { success: false, to: "", error: metaError };
+        const enriched = withIdentity(errResult, { name: sessionName, role: sessionRole, project: sessionProject });
+        return { content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }] };
+      }
       const result = handleDm(
         sessionName,
         String(req.params.arguments?.to ?? ""),
         String(req.params.arguments?.content ?? ""),
-        sessionProject
+        sessionProject,
+        meta
       );
       const enriched = withIdentity(result, { name: sessionName, role: sessionRole, project: sessionProject });
       return { content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }] };
@@ -175,11 +216,22 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       return { content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }] };
     }
     case "broadcast": {
+      const { meta, error: metaError } = buildMeta(
+        req.params.arguments?.priority as string | undefined,
+        req.params.arguments?.message_type as string | undefined,
+        req.params.arguments?.thread_id as string | undefined,
+      );
+      if (metaError) {
+        const errResult = { success: false, from: sessionName, recipientCount: 0, error: metaError };
+        const enriched = withIdentity(errResult, { name: sessionName, role: sessionRole, project: sessionProject });
+        return { content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }] };
+      }
       const result = handleBroadcast(
         SESSION_ID,
         sessionName,
         String(req.params.arguments?.content ?? ""),
-        sessionProject
+        sessionProject,
+        meta
       );
       const enriched = withIdentity(result, { name: sessionName, role: sessionRole, project: sessionProject });
       return { content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }] };
@@ -209,6 +261,7 @@ function startPollLoop(): void {
             params: {
               content: message.content,
               meta: {
+                ...message.meta,
                 from_session: message.from_session,
                 to_session: sessionName,
                 message_id: String(message.id),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -37,6 +37,32 @@ export type Identity = {
   project: string;
 };
 
+const META_KEY_RE = /^[a-zA-Z0-9_]+$/;
+
+export function validateMetaKeys(meta: Record<string, string>): string | null {
+  for (const key of Object.keys(meta)) {
+    if (!META_KEY_RE.test(key)) {
+      return `invalid meta key "${key}" — only letters, digits, and underscores allowed`;
+    }
+  }
+  return null;
+}
+
+export function buildMeta(
+  priority?: string,
+  messageType?: string,
+  threadId?: string,
+): { meta: Record<string, string>; error?: string } {
+  if (threadId && threadId.length > 64) {
+    return { meta: {}, error: "thread_id must be 64 chars or less" };
+  }
+  const meta: Record<string, string> = {};
+  if (priority) meta.priority = priority;
+  if (messageType) meta.message_type = messageType;
+  if (threadId) meta.thread_id = threadId;
+  return { meta };
+}
+
 export function withIdentity<T extends Record<string, unknown>>(
   result: T,
   identity: Identity
@@ -87,7 +113,7 @@ export function handleRegister(sessionId: string, name: string, role: string, pr
   }
 }
 
-export function handleDm(fromName: string, to: string, content: string, senderProject: string = ""): DmResult {
+export function handleDm(fromName: string, to: string, content: string, senderProject: string = "", meta: Record<string, string> = {}): DmResult {
   try {
     if (!fromName || fromName.trim().length === 0) {
       return { success: false, to: "", error: "from is required" };
@@ -100,6 +126,11 @@ export function handleDm(fromName: string, to: string, content: string, senderPr
     }
     if (content.length > 10_000) {
       return { success: false, to: "", error: "content must be under 10000 chars" };
+    }
+
+    const metaError = validateMetaKeys(meta);
+    if (metaError) {
+      return { success: false, to: "", error: metaError };
     }
 
     const cleanTo = sanitize(to);
@@ -120,7 +151,7 @@ export function handleDm(fromName: string, to: string, content: string, senderPr
     let failures = 0;
     for (const recipient of recipients) {
       if (senderProject !== "" && recipient.project !== senderProject) continue;
-      if (!writeMessage(fromName, recipient.id, content)) {
+      if (!writeMessage(fromName, recipient.id, content, meta)) {
         failures++;
       }
     }
@@ -145,7 +176,7 @@ export function handleWho(): WhoResult {
   }
 }
 
-export function handleBroadcast(fromId: string, fromName: string, content: string, senderProject: string = ""): BroadcastResult {
+export function handleBroadcast(fromId: string, fromName: string, content: string, senderProject: string = "", meta: Record<string, string> = {}): BroadcastResult {
   try {
     if (!fromId || fromId.trim().length === 0) {
       return { success: false, from: "", recipientCount: 0, error: "from is required" };
@@ -155,6 +186,11 @@ export function handleBroadcast(fromId: string, fromName: string, content: strin
     }
     if (content.length > 10_000) {
       return { success: false, from: fromName, recipientCount: 0, error: "content must be under 10000 chars" };
+    }
+
+    const metaError = validateMetaKeys(meta);
+    if (metaError) {
+      return { success: false, from: fromName, recipientCount: 0, error: metaError };
     }
 
     const sessions = listActiveSessions();
@@ -173,7 +209,7 @@ export function handleBroadcast(fromId: string, fromName: string, content: strin
     let failures = 0;
 
     for (const session of recipients) {
-      if (!writeMessage(fromName, session.id, content)) {
+      if (!writeMessage(fromName, session.id, content, meta)) {
         failures++;
       }
     }

--- a/tests/bus.test.ts
+++ b/tests/bus.test.ts
@@ -318,6 +318,45 @@ describe("readPendingMessages", () => {
   });
 });
 
+describe("message meta", () => {
+  test("writeMessage stores meta and readPendingMessages returns it", () => {
+    const meta = { priority: "urgent", message_type: "task" };
+    writeMessage("sender", "target-id", "hello", meta);
+    const msgs = readPendingMessages("target-id");
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].meta).toEqual(meta);
+  });
+
+  test("writeMessage without meta defaults to empty object", () => {
+    writeMessage("sender", "target-id", "hello");
+    const msgs = readPendingMessages("target-id");
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].meta).toEqual({});
+  });
+
+  test("readPendingMessages handles corrupted meta JSON gracefully", () => {
+    // Write directly with invalid JSON in meta column
+    const db2 = new Database(tmpDbPath);
+    const now = new Date().toISOString();
+    db2.run(
+      "INSERT INTO messages (from_session, to_session, content, meta, delivered, created_at) VALUES (?, ?, ?, ?, 0, ?)",
+      ["sender", "target-id", "hello", "not-valid-json", now]
+    );
+    db2.close();
+
+    const msgs = readPendingMessages("target-id");
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].meta).toEqual({});
+  });
+
+  test("meta with thread_id round-trips correctly", () => {
+    const meta = { thread_id: "thread-abc123" };
+    writeMessage("sender", "target-id", "hello", meta);
+    const msgs = readPendingMessages("target-id");
+    expect(msgs[0].meta.thread_id).toBe("thread-abc123");
+  });
+});
+
 describe("deleteDeliveredMessage", () => {
   test("deletes the message row", () => {
     writeMessage("sender", "target-id", "msg1");

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -16,6 +16,8 @@ import {
   handleWho,
   handleBroadcast,
   withIdentity,
+  validateMetaKeys,
+  buildMeta,
 } from "../src/tools.js";
 
 let tmpDbPath: string;
@@ -63,6 +65,101 @@ describe("withIdentity", () => {
     const identity = { name: "test", role: "worker", project: "" };
     const enriched = withIdentity(result, identity);
     expect(enriched._identity.project).toBe("");
+  });
+});
+
+describe("validateMetaKeys", () => {
+  test("accepts valid keys", () => {
+    expect(validateMetaKeys({ priority: "urgent", thread_id: "abc" })).toBeNull();
+  });
+
+  test("accepts empty meta", () => {
+    expect(validateMetaKeys({})).toBeNull();
+  });
+
+  test("rejects keys with hyphens", () => {
+    const err = validateMetaKeys({ "my-key": "value" });
+    expect(err).toContain("my-key");
+    expect(err).toContain("invalid meta key");
+  });
+
+  test("rejects keys with dots", () => {
+    const err = validateMetaKeys({ "my.key": "value" });
+    expect(err).toContain("my.key");
+  });
+
+  test("rejects keys with spaces", () => {
+    const err = validateMetaKeys({ "my key": "value" });
+    expect(err).toContain("my key");
+  });
+});
+
+describe("buildMeta", () => {
+  test("builds meta from provided values", () => {
+    const { meta, error } = buildMeta("urgent", "task", "thread-123");
+    expect(error).toBeUndefined();
+    expect(meta).toEqual({ priority: "urgent", message_type: "task", thread_id: "thread-123" });
+  });
+
+  test("omits undefined values", () => {
+    const { meta } = buildMeta("urgent", undefined, undefined);
+    expect(meta).toEqual({ priority: "urgent" });
+  });
+
+  test("returns empty object when all undefined", () => {
+    const { meta } = buildMeta(undefined, undefined, undefined);
+    expect(meta).toEqual({});
+  });
+
+  test("rejects thread_id over 64 chars", () => {
+    const { meta, error } = buildMeta(undefined, undefined, "a".repeat(65));
+    expect(error).toContain("64 chars");
+    expect(meta).toEqual({});
+  });
+
+  test("accepts thread_id at exactly 64 chars", () => {
+    const { meta, error } = buildMeta(undefined, undefined, "a".repeat(64));
+    expect(error).toBeUndefined();
+    expect(meta.thread_id).toBe("a".repeat(64));
+  });
+});
+
+describe("handleDm with meta", () => {
+  test("passes meta through to message bus", () => {
+    registerSession("id-target", "target", "worker", "/tmp");
+    const result = handleDm("sender", "target", "hello", "", { priority: "urgent" });
+    expect(result.success).toBe(true);
+
+    const msgs = readPendingMessages("id-target");
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].meta).toEqual({ priority: "urgent" });
+  });
+
+  test("rejects invalid meta keys", () => {
+    registerSession("id-target2", "target2", "worker", "/tmp");
+    const result = handleDm("sender", "target2", "hello", "", { "bad-key": "value" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("invalid meta key");
+  });
+});
+
+describe("handleBroadcast with meta", () => {
+  test("passes meta through to message bus", () => {
+    registerSession("id-sender", "sender", "worker", "/tmp");
+    registerSession("id-receiver", "receiver", "worker", "/tmp");
+    const result = handleBroadcast("id-sender", "sender", "hello", "", { message_type: "status" });
+    expect(result.success).toBe(true);
+
+    const msgs = readPendingMessages("id-receiver");
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].meta).toEqual({ message_type: "status" });
+  });
+
+  test("rejects invalid meta keys", () => {
+    registerSession("id-s", "s", "worker", "/tmp");
+    const result = handleBroadcast("id-s", "s", "hello", "", { "dot.key": "value" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("invalid meta key");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds optional `priority`, `message_type`, and `thread_id` metadata to `dm` and `broadcast` tools
- New `meta TEXT` column on messages table with JSON storage and automatic schema migration
- Meta keys validated against channel protocol constraints (letters, digits, underscores only)
- Stored meta spread before hardcoded routing fields in poll loop to prevent spoofing
- `thread_id` enforced at both schema level (`maxLength: 64`) and runtime (`buildMeta` validation)

## Test plan
- [x] 112 tests pass (94 existing + 18 new), zero regressions
- [x] `bun run typecheck` passes
- [x] Meta round-trip: write with meta → read → verify fields preserved
- [x] Corrupted JSON fallback: malformed meta in DB → defaults to `{}`
- [x] Key validation: rejects hyphens, dots, spaces
- [x] thread_id length enforcement at 64 chars
- [x] handleDm/handleBroadcast pass meta through to bus
- [x] Existing tests unmodified and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)