### PR TITLE
feat: add permission relay for remote tool approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `validateMetaKeys()` and `buildMeta()` helpers in `tools.ts` — meta keys validated against channel protocol constraints (letters, digits, underscores only)
 - Stored meta attributes included in channel notification delivery — user meta spread BEFORE hardcoded routing fields to prevent spoofing
 - 16 new tests for meta round-trip, key validation, corrupted JSON fallback, and tool integration (110 total)
+- Permission relay — opt-in via `CC_DM_PERMISSION_RELAY=1`, enables remote tool approval/denial across sessions using the `claude/channel/permission` protocol capability
+- `CC_DM_PERMISSION_APPROVER` env var for targeted relay to a specific session (otherwise broadcasts to all project sessions)
+- `src/permission.ts` — pure functions: `VERDICT_RE`, `parseVerdict()`, `formatPermissionRequest()`
+- Verdict interception in poll loop — messages matching the verdict regex with a pending request ID are emitted as `notifications/claude/channel/permission` instead of regular channel notifications
+- In-memory `pendingPermissions` map with 5-minute expiry for stale requests
+- 20 new tests for VERDICT_RE matching, parseVerdict, formatPermissionRequest (132 total)
 
 ## [1.2.0] - 2026-03-27
 

--- a/src/permission.ts
+++ b/src/permission.ts
@@ -1,0 +1,31 @@
+// Pure functions for permission relay: verdict parsing and request formatting.
+
+export const VERDICT_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i;
+
+export function parseVerdict(content: string): { requestId: string; behavior: "allow" | "deny" } | null {
+  const match = VERDICT_RE.exec(content);
+  if (!match) return null;
+  const answer = match[1].toLowerCase();
+  const requestId = match[2].toLowerCase();
+  const behavior = (answer === "y" || answer === "yes") ? "allow" : "deny";
+  return { requestId, behavior };
+}
+
+export type PermissionRequestParams = {
+  requestId: string;
+  toolName: string;
+  description: string;
+  inputPreview: string;
+  fromSession: string;
+};
+
+export function formatPermissionRequest(params: PermissionRequestParams): string {
+  return [
+    `[Permission Request] Session "${params.fromSession}" wants to use ${params.toolName}:`,
+    `  ${params.description}`,
+    params.inputPreview ? `  Input: ${params.inputPreview}` : "",
+    `  Request ID: ${params.requestId}`,
+    "",
+    `Reply with "yes ${params.requestId}" to approve or "no ${params.requestId}" to deny.`,
+  ].filter(Boolean).join("\n");
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,10 +6,12 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 import { initBus, readPendingMessages, deleteDeliveredMessage, deregisterSession, registerSession } from "./bus.js";
 import { handleDm, handleWho, handleRegister, handleBroadcast, withIdentity, buildMeta } from "./tools.js";
 import { startHeartbeat, stopHeartbeat } from "./heartbeat.js";
 import { sanitize } from "./sanitize.js";
+import { parseVerdict, formatPermissionRequest } from "./permission.js";
 
 const SESSION_ID = `session-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
 
@@ -34,6 +36,9 @@ let sessionName = SESSION_NAME;
 let sessionRole = SESSION_ROLE;
 let sessionProject = SESSION_PROJECT;
 
+const PERMISSION_RELAY = process.env.CC_DM_PERMISSION_RELAY === "1";
+const PERMISSION_APPROVER = process.env.CC_DM_PERMISSION_APPROVER?.trim() || "";
+
 type ChannelNotification = {
   method: "notifications/claude/channel";
   params: {
@@ -41,6 +46,40 @@ type ChannelNotification = {
     meta: Record<string, string>;
   };
 };
+
+type PermissionVerdict = {
+  method: "notifications/claude/channel/permission";
+  params: {
+    request_id: string;
+    behavior: "allow" | "deny";
+  };
+};
+
+type PendingPermission = {
+  requestId: string;
+  timestamp: number;
+};
+
+const pendingPermissions = new Map<string, PendingPermission>();
+
+const PERMISSION_EXPIRY_MS = 5 * 60 * 1000;
+
+function cleanupExpiredPermissions(): void {
+  const cutoff = Date.now() - PERMISSION_EXPIRY_MS;
+  for (const [id, entry] of pendingPermissions) {
+    if (entry.timestamp < cutoff) pendingPermissions.delete(id);
+  }
+}
+
+const PermissionRequestNotificationSchema = z.object({
+  method: z.literal("notifications/claude/channel/permission_request"),
+  params: z.object({
+    request_id: z.string(),
+    tool_name: z.string(),
+    description: z.string(),
+    input_preview: z.string(),
+  }),
+});
 
 function buildRegistrationInstruction(): string {
   if (NAME_PROVIDED && ROLE_PROVIDED) {
@@ -57,14 +96,23 @@ function buildRegistrationInstruction(): string {
 
 const registrationInstruction = buildRegistrationInstruction();
 
-const server = new Server<never, ChannelNotification>(
+const experimentalCapabilities: Record<string, object> = { "claude/channel": {} };
+if (PERMISSION_RELAY) {
+  experimentalCapabilities["claude/channel/permission"] = {};
+}
+
+const permissionNote = PERMISSION_RELAY
+  ? ` Tool approvals for this session are relayed via cc-dm${PERMISSION_APPROVER ? ` to "${PERMISSION_APPROVER}"` : " to all project sessions"}. Approvals may take longer than usual.`
+  : "";
+
+const server = new Server<never, ChannelNotification | PermissionVerdict>(
   { name: "cc-dm", version: "1.2.0" },
   {
     capabilities: {
-      experimental: { "claude/channel": {} },
+      experimental: experimentalCapabilities,
       tools: {},
     },
-    instructions: `You are connected to cc-dm. Your session id is "${SESSION_ID}". ${registrationInstruction} Messages from other sessions arrive as <channel source="cc-dm" from_session="..." to_session="...">. Act on messages addressed to your session name. Available tools: register, dm, who, broadcast.`,
+    instructions: `You are connected to cc-dm. Your session id is "${SESSION_ID}". ${registrationInstruction}${permissionNote} Messages from other sessions arrive as <channel source="cc-dm" from_session="..." to_session="...">. Act on messages addressed to your session name. Available tools: register, dm, who, broadcast.`,
   }
 );
 
@@ -247,6 +295,7 @@ const deliveredIds = new Set<number>();
 function startPollLoop(): void {
   pollTimer = setInterval(async () => {
     try {
+      cleanupExpiredPermissions();
       const messages = readPendingMessages(SESSION_ID);
       if (messages.length === 0) return;
 
@@ -255,6 +304,29 @@ function startPollLoop(): void {
           try { deleteDeliveredMessage(message.id); } catch (err) { console.error(`[cc-dm/poll] retry delete failed for message ${message.id}:`, err); }
           continue;
         }
+
+        // Verdict interception: check if this message is a permission verdict
+        if (PERMISSION_RELAY && pendingPermissions.size > 0) {
+          const verdict = parseVerdict(message.content);
+          if (verdict && pendingPermissions.has(verdict.requestId)) {
+            try {
+              await server.notification({
+                method: "notifications/claude/channel/permission",
+                params: {
+                  request_id: verdict.requestId,
+                  behavior: verdict.behavior,
+                },
+              });
+              pendingPermissions.delete(verdict.requestId);
+              console.error(`[cc-dm/permission] verdict "${verdict.behavior}" for request ${verdict.requestId} from ${message.from_session}`);
+              deleteDeliveredMessage(message.id);
+            } catch (err) {
+              console.error(`[cc-dm/permission] failed to deliver verdict for ${verdict.requestId}:`, err);
+            }
+            continue;
+          }
+        }
+
         try {
           await server.notification({
             method: "notifications/claude/channel",
@@ -306,6 +378,33 @@ async function main(): Promise<void> {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  if (PERMISSION_RELAY) {
+    server.setNotificationHandler(PermissionRequestNotificationSchema, async ({ params }) => {
+      const { request_id, tool_name, description, input_preview } = params;
+      pendingPermissions.set(request_id, { requestId: request_id, timestamp: Date.now() });
+      const content = formatPermissionRequest({
+        requestId: request_id,
+        toolName: tool_name,
+        description,
+        inputPreview: input_preview,
+        fromSession: sessionName,
+      });
+
+      if (PERMISSION_APPROVER) {
+        const result = handleDm(sessionName, PERMISSION_APPROVER, content, sessionProject);
+        if (!result.success) {
+          console.error(`[cc-dm/permission] failed to relay request ${request_id} to "${PERMISSION_APPROVER}": ${result.error}`);
+        } else {
+          console.error(`[cc-dm/permission] relayed request ${request_id} (${tool_name}) to "${PERMISSION_APPROVER}"`);
+        }
+      } else {
+        const result = handleBroadcast(SESSION_ID, sessionName, content, sessionProject);
+        console.error(`[cc-dm/permission] broadcast request ${request_id} (${tool_name}) to ${result.recipientCount} session(s)`);
+      }
+    });
+    console.error(`[cc-dm/permission] relay enabled${PERMISSION_APPROVER ? ` → approver: "${PERMISSION_APPROVER}"` : " → broadcast to project"}`);
+  }
 
   startHeartbeat(SESSION_ID, () => {
     try {

--- a/tests/permission.test.ts
+++ b/tests/permission.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from "bun:test";
+import { parseVerdict, formatPermissionRequest, VERDICT_RE } from "../src/permission.js";
+
+describe("VERDICT_RE", () => {
+  test("matches 'yes xxxxx'", () => {
+    expect(VERDICT_RE.test("yes abcde")).toBe(true);
+  });
+
+  test("matches 'no xxxxx'", () => {
+    expect(VERDICT_RE.test("no abcde")).toBe(true);
+  });
+
+  test("matches 'y xxxxx'", () => {
+    expect(VERDICT_RE.test("y abcde")).toBe(true);
+  });
+
+  test("matches 'n xxxxx'", () => {
+    expect(VERDICT_RE.test("n abcde")).toBe(true);
+  });
+
+  test("matches with leading/trailing whitespace", () => {
+    expect(VERDICT_RE.test("  yes abcde  ")).toBe(true);
+  });
+
+  test("is case-insensitive", () => {
+    expect(VERDICT_RE.test("YES ABCDE")).toBe(true);
+    expect(VERDICT_RE.test("No AbCdE")).toBe(true);
+  });
+
+  test("rejects IDs with excluded chars (l, I, 1)", () => {
+    expect(VERDICT_RE.test("yes abcle")).toBe(false);
+  });
+
+  test("rejects IDs shorter than 5 chars", () => {
+    expect(VERDICT_RE.test("yes abcd")).toBe(false);
+  });
+
+  test("rejects IDs longer than 5 chars", () => {
+    expect(VERDICT_RE.test("yes abcdef")).toBe(false);
+  });
+
+  test("rejects messages with extra text", () => {
+    expect(VERDICT_RE.test("yes abcde sounds good")).toBe(false);
+  });
+
+  test("rejects non-verdict messages", () => {
+    expect(VERDICT_RE.test("hello world")).toBe(false);
+    expect(VERDICT_RE.test("")).toBe(false);
+  });
+});
+
+describe("parseVerdict", () => {
+  test("parses 'yes xxxxx' as allow", () => {
+    const result = parseVerdict("yes abcde");
+    expect(result).toEqual({ requestId: "abcde", behavior: "allow" });
+  });
+
+  test("parses 'y xxxxx' as allow", () => {
+    const result = parseVerdict("y abcde");
+    expect(result).toEqual({ requestId: "abcde", behavior: "allow" });
+  });
+
+  test("parses 'no xxxxx' as deny", () => {
+    const result = parseVerdict("no abcde");
+    expect(result).toEqual({ requestId: "abcde", behavior: "deny" });
+  });
+
+  test("parses 'n xxxxx' as deny", () => {
+    const result = parseVerdict("n abcde");
+    expect(result).toEqual({ requestId: "abcde", behavior: "deny" });
+  });
+
+  test("normalizes requestId to lowercase", () => {
+    const result = parseVerdict("YES ABCDE");
+    expect(result!.requestId).toBe("abcde");
+  });
+
+  test("returns null for non-verdict content", () => {
+    expect(parseVerdict("hello world")).toBeNull();
+    expect(parseVerdict("")).toBeNull();
+    expect(parseVerdict("yes abcde extra text")).toBeNull();
+  });
+
+  test("returns null for IDs with excluded chars", () => {
+    expect(parseVerdict("yes abcle")).toBeNull();
+  });
+});
+
+describe("formatPermissionRequest", () => {
+  test("formats a complete permission request message", () => {
+    const msg = formatPermissionRequest({
+      requestId: "abcde",
+      toolName: "Bash",
+      description: "Execute a shell command",
+      inputPreview: '{"command": "rm -rf dist/"}',
+      fromSession: "worker-1",
+    });
+    expect(msg).toContain("[Permission Request]");
+    expect(msg).toContain("worker-1");
+    expect(msg).toContain("Bash");
+    expect(msg).toContain("abcde");
+    expect(msg).toContain("rm -rf dist/");
+    expect(msg).toContain("yes abcde");
+    expect(msg).toContain("no abcde");
+  });
+
+  test("handles empty inputPreview", () => {
+    const msg = formatPermissionRequest({
+      requestId: "fghkm",
+      toolName: "Write",
+      description: "Write a file",
+      inputPreview: "",
+      fromSession: "backend",
+    });
+    expect(msg).toContain("Write");
+    expect(msg).toContain("fghkm");
+    expect(msg).not.toContain("Input:");
+  });
+});


### PR DESCRIPTION
## Summary
- Opt-in permission relay via `CC_DM_PERMISSION_RELAY=1` — enables remote approval/denial of tool calls using `claude/channel/permission` capability
- `CC_DM_PERMISSION_APPROVER` env var routes requests to a specific session (otherwise broadcasts to project)
- New `src/permission.ts` with pure functions: `VERDICT_RE`, `parseVerdict()`, `formatPermissionRequest()`
- Verdict interception in poll loop — messages matching verdict regex with pending request ID are emitted as permission notifications instead of regular channel events
- In-memory pending permissions map with 5-minute expiry

## Test plan
- [x] 132 tests pass (112 existing + 20 new), zero regressions
- [x] `bun run typecheck` passes
- [x] VERDICT_RE: valid matches, exclusion chars, length, extra text rejection
- [x] parseVerdict: allow/deny mapping, shorthand, normalization, null returns
- [x] formatPermissionRequest: complete message format, empty preview handling
- [x] Capability only declared when `CC_DM_PERMISSION_RELAY=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)