### PR TITLE
feat: add role-based access control for broadcast and DM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Verdict interception in poll loop — messages matching the verdict regex with a pending request ID are emitted as `notifications/claude/channel/permission` instead of regular channel notifications
 - In-memory `pendingPermissions` map with 5-minute expiry for stale requests
 - 20 new tests for VERDICT_RE matching, parseVerdict, formatPermissionRequest (132 total)
+- Role-based access control — `CC_DM_BROADCAST_ALLOWED_ROLES` restricts which roles can broadcast, `CC_DM_DM_ALLOWLIST` / `CC_DM_DM_BLOCKLIST` restrict DM targets (mutually exclusive, fatal error if both set)
+- 8 new tests for DM allowlist/blocklist guards and broadcast role restriction (140 total)
 
 ## [1.2.0] - 2026-03-27
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,32 @@ let sessionProject = SESSION_PROJECT;
 const PERMISSION_RELAY = process.env.CC_DM_PERMISSION_RELAY === "1";
 const PERMISSION_APPROVER = process.env.CC_DM_PERMISSION_APPROVER?.trim() || "";
 
+const BROADCAST_ALLOWED_ROLES = new Set(
+  (process.env.CC_DM_BROADCAST_ALLOWED_ROLES?.trim() || "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+);
+
+const DM_ALLOWLIST = new Set(
+  (process.env.CC_DM_DM_ALLOWLIST?.trim() || "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+);
+
+const DM_BLOCKLIST = new Set(
+  (process.env.CC_DM_DM_BLOCKLIST?.trim() || "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+);
+
+if (DM_ALLOWLIST.size > 0 && DM_BLOCKLIST.size > 0) {
+  console.error("[cc-dm] Fatal: CC_DM_DM_ALLOWLIST and CC_DM_DM_BLOCKLIST are mutually exclusive. Set one or neither.");
+  process.exit(1);
+}
+
 type ChannelNotification = {
   method: "notifications/claude/channel";
   params: {
@@ -253,7 +279,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         String(req.params.arguments?.to ?? ""),
         String(req.params.arguments?.content ?? ""),
         sessionProject,
-        meta
+        meta,
+        DM_ALLOWLIST,
+        DM_BLOCKLIST
       );
       const enriched = withIdentity(result, { name: sessionName, role: sessionRole, project: sessionProject });
       return { content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }] };
@@ -279,7 +307,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         sessionName,
         String(req.params.arguments?.content ?? ""),
         sessionProject,
-        meta
+        meta,
+        sessionRole,
+        BROADCAST_ALLOWED_ROLES
       );
       const enriched = withIdentity(result, { name: sessionName, role: sessionRole, project: sessionProject });
       return { content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }] };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -113,7 +113,7 @@ export function handleRegister(sessionId: string, name: string, role: string, pr
   }
 }
 
-export function handleDm(fromName: string, to: string, content: string, senderProject: string = "", meta: Record<string, string> = {}): DmResult {
+export function handleDm(fromName: string, to: string, content: string, senderProject: string = "", meta: Record<string, string> = {}, dmAllowlist: Set<string> = new Set(), dmBlocklist: Set<string> = new Set()): DmResult {
   try {
     if (!fromName || fromName.trim().length === 0) {
       return { success: false, to: "", error: "from is required" };
@@ -134,6 +134,13 @@ export function handleDm(fromName: string, to: string, content: string, senderPr
     }
 
     const cleanTo = sanitize(to);
+
+    if (dmAllowlist.size > 0 && !dmAllowlist.has(cleanTo)) {
+      return { success: false, to: cleanTo, error: `"${cleanTo}" is not in this session's DM allowlist` };
+    }
+    if (dmBlocklist.size > 0 && dmBlocklist.has(cleanTo)) {
+      return { success: false, to: cleanTo, error: `"${cleanTo}" is blocked by this session's DM blocklist` };
+    }
     const recipients = findSessionsByName(cleanTo);
     if (recipients.length === 0) {
       return { success: false, to: cleanTo, error: "no active session with that name" };
@@ -176,7 +183,7 @@ export function handleWho(): WhoResult {
   }
 }
 
-export function handleBroadcast(fromId: string, fromName: string, content: string, senderProject: string = "", meta: Record<string, string> = {}): BroadcastResult {
+export function handleBroadcast(fromId: string, fromName: string, content: string, senderProject: string = "", meta: Record<string, string> = {}, senderRole: string = "", broadcastAllowedRoles: Set<string> = new Set()): BroadcastResult {
   try {
     if (!fromId || fromId.trim().length === 0) {
       return { success: false, from: "", recipientCount: 0, error: "from is required" };
@@ -186,6 +193,10 @@ export function handleBroadcast(fromId: string, fromName: string, content: strin
     }
     if (content.length > 10_000) {
       return { success: false, from: fromName, recipientCount: 0, error: "content must be under 10000 chars" };
+    }
+
+    if (broadcastAllowedRoles.size > 0 && !broadcastAllowedRoles.has(senderRole)) {
+      return { success: false, from: fromName, recipientCount: 0, error: `role "${senderRole}" is not permitted to broadcast` };
     }
 
     const metaError = validateMetaKeys(meta);

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -163,6 +163,71 @@ describe("handleBroadcast with meta", () => {
   });
 });
 
+describe("handleDm access control", () => {
+  test("allowlist permits listed targets", () => {
+    registerSession("id-alice", "alice", "worker", "/tmp");
+    const allow = new Set(["alice"]);
+    const result = handleDm("sender", "alice", "hi", "", {}, allow, new Set());
+    expect(result.success).toBe(true);
+  });
+
+  test("allowlist blocks unlisted targets", () => {
+    registerSession("id-bob", "bob", "worker", "/tmp");
+    const allow = new Set(["alice"]);
+    const result = handleDm("sender", "bob", "hi", "", {}, allow, new Set());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("allowlist");
+  });
+
+  test("blocklist blocks listed targets", () => {
+    registerSession("id-charlie", "charlie", "worker", "/tmp");
+    const block = new Set(["charlie"]);
+    const result = handleDm("sender", "charlie", "hi", "", {}, new Set(), block);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("blocklist");
+  });
+
+  test("blocklist permits unlisted targets", () => {
+    registerSession("id-dave", "dave", "worker", "/tmp");
+    const block = new Set(["other"]);
+    const result = handleDm("sender", "dave", "hi", "", {}, new Set(), block);
+    expect(result.success).toBe(true);
+  });
+
+  test("empty sets impose no restriction", () => {
+    registerSession("id-eve", "eve", "worker", "/tmp");
+    const result = handleDm("sender", "eve", "hi", "", {}, new Set(), new Set());
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("handleBroadcast access control", () => {
+  test("allowed role can broadcast", () => {
+    registerSession("id-orch", "orch", "orchestrator", "/tmp");
+    registerSession("id-recv", "recv", "worker", "/tmp");
+    const allowed = new Set(["orchestrator"]);
+    const result = handleBroadcast("id-orch", "orch", "hello", "", {}, "orchestrator", allowed);
+    expect(result.success).toBe(true);
+    expect(result.recipientCount).toBe(1);
+  });
+
+  test("disallowed role cannot broadcast", () => {
+    registerSession("id-wrk", "wrk", "worker", "/tmp");
+    registerSession("id-rcv2", "rcv2", "worker", "/tmp");
+    const allowed = new Set(["orchestrator"]);
+    const result = handleBroadcast("id-wrk", "wrk", "hello", "", {}, "worker", allowed);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not permitted to broadcast");
+  });
+
+  test("empty allowed roles imposes no restriction", () => {
+    registerSession("id-any", "any", "intern", "/tmp");
+    registerSession("id-rcv3", "rcv3", "worker", "/tmp");
+    const result = handleBroadcast("id-any", "any", "hello", "", {}, "intern", new Set());
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("handleRegister", () => {
   test("validates empty name", () => {
     const result = handleRegister("test-id", "", "worker");


### PR DESCRIPTION
## Summary
- `CC_DM_BROADCAST_ALLOWED_ROLES` restricts which roles can broadcast (comma-separated)
- `CC_DM_DM_ALLOWLIST` / `CC_DM_DM_BLOCKLIST` restrict DM targets (mutually exclusive — fatal error if both set)
- All sender-side, env var config at startup, zero new tables or tools
- Permission relay internal calls bypass access control via default empty params

## Test plan
- [x] 140 tests pass (132 existing + 8 new), zero regressions
- [x] `bun run typecheck` passes
- [x] DM allowlist: permits listed, blocks unlisted, empty = no restriction
- [x] DM blocklist: blocks listed, permits unlisted
- [x] Broadcast role: allowed role succeeds, disallowed fails, empty = no restriction

🤖 Generated with [Claude Code](https://claude.com/claude-code)